### PR TITLE
Add requests-cache dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'requests',
+        'requests-cache'
     ],
     tests_require=[],
     entry_points=\


### PR DESCRIPTION
I tried to run the example code from your README in a brand new virtualenv, and got the error:

```
Traceback (most recent call last):
  File "./main.py", line 3, in <module>
    import zoopla
  File "/Users/…/.virtualenvs/zoopla/src/zoopla/zoopla/__init__.py", line 1, in <module>
    from api_factory import api
  File "/Users/…/.virtualenvs/zoopla/src/zoopla/zoopla/api_factory.py", line 4, in <module>
    from api_v1 import _ApiVersion1
  File "/Users/…/.virtualenvs/zoopla/src/zoopla/zoopla/api_v1.py", line 5, in <module>
    import requests_cache
ImportError: No module named requests_cache
```

Unless I'm missing something, I assume `requests-cache` should be in your `setup.py`…?
